### PR TITLE
Fix documentation of usage to correct widget name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ dependencies:
 import 'package:sizer/sizer.dart';
 ```
 
-## Wrap MaterialApp with ResponsiveSizer widget
+## Wrap MaterialApp with Sizer widget
 ```dart
-ResponsiveSizer(
+Sizer(
       builder: (context, orientation, deviceType) {
         return MaterialApp();
       }


### PR DESCRIPTION
The example in the README was incorrect, it referred to "ResponsiveSizer" which doesn't exist, instead of the correct widget "Sizer".  This change just updates that error in the README.

(When I first tried this component I found it very confusing when the simple example given in the README failed to compile).

